### PR TITLE
ci: optimize nix ci time with store cache and nixbuild/nix-quick-install-action

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -6,7 +6,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  nix-build:
+  setup:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -15,19 +15,17 @@ jobs:
           - macos-latest
       fail-fast: false
 
-    name: nix-build (${{ matrix.os }})
+    name: setup (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v3
-      - &install
-        uses: nixbuild/nix-quick-install-action@v25
+      - uses: nixbuild/nix-quick-install-action@v25
         with:
           nix_conf: |
             substituters = https://cache.nixos.org/ https://nix-community.cachix.org
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
             keep-outputs = true
 
-      - &cache
-        name: Restore and cache Nix store
+      - name: Restore and cache Nix store
         uses: nix-community/cache-nix-action@v1
         with:
           linux-gc-enabled: true
@@ -43,9 +41,22 @@ jobs:
             cache-${{ matrix.os }}-${{ hashFiles('.github/workflows/ci.yaml') }}-
             cache-${{ matrix.os }}-
 
+  nix-build:
+    needs: setup
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+      fail-fast: false
+
+    name: nix-build (${{ matrix.os }})
+    steps:
       - run: nix build
 
   nix-show:
+    needs: setup
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -56,12 +67,10 @@ jobs:
 
     name: nix-show (${{ matrix.os }})
     steps:
-      - uses: actions/checkout@v3
-      - *install
-      - *cache
       - run: nix flake show
 
   nix-test:
+    needs: setup
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -72,9 +81,6 @@ jobs:
 
     name: nix-test (${{ matrix.os }})
     steps:
-      - uses: actions/checkout@v3
-      - *install
-      - *cache
       - run: nix run . -- --version
       - run: nix run . -- -l scripts/test.lua
 

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -41,46 +41,14 @@ jobs:
             cache-${{ matrix.os }}-${{ hashFiles('.github/workflows/ci.yaml') }}-
             cache-${{ matrix.os }}-
 
-  nix-build:
-    needs: setup
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-      fail-fast: false
+      - name: nix-build (${{ matrix.os }})
+        run: nix build
 
-    name: nix-build (${{ matrix.os }})
-    steps:
-      - run: nix build
+      - name: nix-show
+        run: nix flake show
 
-  nix-show:
-    needs: setup
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-      fail-fast: false
-
-    name: nix-show (${{ matrix.os }})
-    steps:
-      - run: nix flake show
-
-  nix-test:
-    needs: setup
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-      fail-fast: false
-
-    name: nix-test (${{ matrix.os }})
-    steps:
-      - run: nix run . -- --version
-      - run: nix run . -- -l scripts/test.lua
+      - name: nix-test
+        run: |
+          nix run . -- --version
+          nix run . -- -l scripts/test.lua
 

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,9 +1,9 @@
-name: nix-build
+name: nix
 
 on:
   pull_request:
   push:
-    branches: ["master"]
+    branches: [ "master" ]
 
 jobs:
   nix-build:
@@ -18,7 +18,63 @@ jobs:
     name: nix-build (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v22
+      - &install
+        uses: nixbuild/nix-quick-install-action@v25
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          nix_conf: |
+            substituters = https://cache.nixos.org/ https://nix-community.cachix.org
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+            keep-outputs = true
+
+      - &cache
+        name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v1
+        with:
+          linux-gc-enabled: true
+          # 8 gb
+          linux-max-store-size: 8000000000
+          macos-gc-enabled: true
+          # 8 gb
+          macos-max-store-size: 8000000000
+
+          # save a new cache every time
+          key: cache-${{ matrix.os }}-${{ hashFiles('.github/workflows/ci.yaml') }}
+          restore-keys: |
+            cache-${{ matrix.os }}-${{ hashFiles('.github/workflows/ci.yaml') }}-
+            cache-${{ matrix.os }}-
+
       - run: nix build
+
+  nix-show:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+      fail-fast: false
+
+    name: nix-show (${{ matrix.os }})
+    steps:
+      - uses: actions/checkout@v3
+      - *install
+      - *cache
+      - run: nix flake show
+
+  nix-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+      fail-fast: false
+
+    name: nix-test (${{ matrix.os }})
+    steps:
+      - uses: actions/checkout@v3
+      - *install
+      - *cache
+      - run: nix run . -- --version
+      - run: nix run . -- -l scripts/test.lua
+


### PR DESCRIPTION
- Should be drop-in replacement that gives us `nix-community/cache-nix-action`

- <details>
  <summary>Using 8 GB for `/nix/store`</summary> if `/nix/store` usage is higher, then a garbage collection job is called before cache persistence is done to make sure that we're caching at most 8 GB of store.
  </details>

- Erases `github_access_token` - unsure how this affects the overall CI