### PR TITLE
refactor: hide info buffer and set nomodifable

### DIFF
--- a/plugin/sg.lua
+++ b/plugin/sg.lua
@@ -33,6 +33,10 @@ vim.api.nvim_create_user_command("SourcegraphInfo", function()
 
   vim.cmd.vnew()
   vim.api.nvim_buf_set_lines(0, 0, -1, false, contents)
+  vim.api.nvim_buf_set_option(0, "buflisted", false)
+  vim.api.nvim_buf_set_option(0, "bufhidden", "wipe")
+  vim.api.nvim_buf_set_option(0, "modifiable", false)
+  vim.api.nvim_buf_set_option(0, "modified", false)
 
   vim.schedule(function()
     print "... got sourcegraph info"


### PR DESCRIPTION
Tiny PR.

There have been a few times I've had to run `SourcegraphInfo` repeatedly to check whether I was successfully logged in. Each time it creates a buffer and modifies it, leaving an unused and unwritten buffer around afterwards. Figured it would make more sense as a scratch buffer so I don't need to spend an extra second `:q!`-ing it :)