### PR TITLE
fix: Use jobwait instead of vim.wait

### DIFF
--- a/build/init.lua
+++ b/build/init.lua
@@ -33,7 +33,7 @@ print "====================="
 -- Wait for up to ten minutes...? Idk, maybe that's too long
 -- or short haha. I don't know what build times are for other people
 local wait_for_status = function(status)
-  vim.fn.jobwait { status.jid }
+  vim.fn.jobwait({ status.jid }, 10 * 60 * 1000)
 end
 
 local status_workspace = system { "cargo", "build", "--workspace" }

--- a/build/init.lua
+++ b/build/init.lua
@@ -19,12 +19,10 @@ local system = function(cmd, opts)
     if code ~= 0 then
       error("failed to execute: " .. table.concat(cmd, " "))
     end
-
-    status.done = true
     print ""
   end
 
-  vim.fn.jobstart(cmd, opts)
+  status.jid = vim.fn.jobstart(cmd, opts)
   return status
 end
 
@@ -35,9 +33,7 @@ print "====================="
 -- Wait for up to ten minutes...? Idk, maybe that's too long
 -- or short haha. I don't know what build times are for other people
 local wait_for_status = function(status)
-  vim.wait(10 * 60 * 1000, function()
-    return status.done
-  end, 10)
+  vim.fn.jobwait { status.jid }
 end
 
 local status_workspace = system { "cargo", "build", "--workspace" }


### PR DESCRIPTION
Hi,

In the current version of the build script, if one of the cargo commands fail, the [`error` call](https://github.com/sourcegraph/sg.nvim/blob/7de5e1577800560b2a94c0618fdccc67b74fa620/build/init.lua#L20) prevents the [setting of the done flag](https://github.com/sourcegraph/sg.nvim/blob/7de5e1577800560b2a94c0618fdccc67b74fa620/build/init.lua#L23) causing the build to hand for 10 min (or 20 if both commands fail).

The simplest fix would be to move the line "status.done = true" over the `if`, but I think the best way to handle this is to rely on `jobwait`, since the task is launched with `jobstart`.
