### PR TITLE
Cancel Cody completions

### DIFF
--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -117,6 +117,10 @@ Default commands for interacting with Cody
 
     Use from visual mode to pass the current selection
 
+                                                                 *:CodyCancel*
+:CodyCancel ~
+    Cancels all active Cody completions.
+
                                                                    *:CodyChat*
 :CodyChat {module} ~
     State a new cody chat, with an optional {title}

--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -160,6 +160,11 @@ commands.ask({bufnr}, {start_line}, {end_line}, {message})     *sg.cody.ask()*
         {message}    (string)
 
 
+commands.cancel()                                           *sg.cody.cancel()*
+    Cancels any running Cody completions
+
+
+
 commands.chat({name})                                         *sg.cody.chat()*
     Start a new CodyChat
 

--- a/lua/sg/cody/commands.lua
+++ b/lua/sg/cody/commands.lua
@@ -61,6 +61,11 @@ commands.ask = function(bufnr, start_line, end_line, message)
   end)
 end
 
+--- Cancels any running Cody completions
+commands.cancel = function()
+  require("sg.cody.rpc").message_callbacks = {}
+end
+
 --- Start a new CodyChat
 ---@param name string?
 ---@return CodyLayout

--- a/lua/sg/components/cody_layout.lua
+++ b/lua/sg/components/cody_layout.lua
@@ -156,6 +156,9 @@ function CodyLayout:mount()
   --   self.prompt:on_submit { request_embeddings = true }
   -- end)
 
+  keymaps.map(self.prompt.bufnr, "n", "<c-c>", "[cody] cancel completions", function()
+    vim.cmd "CodyCancel"
+  end)
   keymaps.map(self.prompt.bufnr, "i", "<c-c>", "[cody] quit chat", function()
     self.prompt:on_close()
   end)

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -30,6 +30,10 @@ vim.api.nvim_create_user_command("CodyAsk", function(command)
   cody_commands.ask(bufnr, command.line1 - 1, command.line2, command.args)
 end, { range = 2, nargs = 1 })
 
+vim.api.nvim_create_user_command("CodyCancel", function()
+  cody_commands.cancel()
+end, {})
+
 -- TODO: This isn't ready yet, but we should explore how to expose this
 -- ---@command CodyRecipes [[
 -- --- Use cody recipes on a selection

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -30,6 +30,9 @@ vim.api.nvim_create_user_command("CodyAsk", function(command)
   cody_commands.ask(bufnr, command.line1 - 1, command.line2, command.args)
 end, { range = 2, nargs = 1 })
 
+---@command CodyCancel [[
+--- Cancels all active Cody completions.
+---@command ]]
 vim.api.nvim_create_user_command("CodyCancel", function()
   cody_commands.cancel()
 end, {})


### PR DESCRIPTION
Very bare-bones implementation for #74

Adds a command to cancel all active completion jobs by removing their callback handlers.

We need some more control over which completion gets cancelled, and a way to default to the best completion to cancel (i.e. the completion running in the buffer we're in).

What if there are multiple completions running in a buffer? Do we cancel all of them? (probably)