### PR TITLE
feat: add cody_{prompt|history} filetypes

### DIFF
--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -30,6 +30,10 @@ All options can be set via
   require("sg").setup { ... }
 <
 
+Other configuration notes:
+- To configure options for the prompt, you can use `ftplugin/cody_prompt.lua`
+- To configure options for the history, you can use `ftplugin/cody_history.lua`
+
 sg.config                                                          *sg.config*
 
 

--- a/lua/sg/components/cody_history.lua
+++ b/lua/sg/components/cody_history.lua
@@ -35,8 +35,9 @@ function CodyHistory:show()
   self:open()
 
   vim.api.nvim_buf_set_name(self.bufnr, string.format("Cody History (%d)", self.bufnr))
-  vim.bo[self.bufnr].filetype = self.opts.filetype or "markdown"
   vim.wo[self.win].foldmethod = "marker"
+
+  vim.bo[self.bufnr].filetype = self.opts.filetype or "markdown.cody_history"
 end
 
 function CodyHistory:delete()

--- a/lua/sg/components/cody_prompt.lua
+++ b/lua/sg/components/cody_prompt.lua
@@ -1,9 +1,5 @@
 local shared = require "sg.components.shared"
 
--- exiting insert mode places cursor one character backward,
--- so patch the cursor position to one character forward
--- when unmounting input.
-
 ---@class CodyPromptSubmitOptions
 ---@field request_embeddings boolean
 
@@ -17,6 +13,7 @@ local shared = require "sg.components.shared"
 ---@field on_submit function(bufnr: number, text: string[], opts: CodyPromptSubmitOptions): void
 ---@field on_change function?
 ---@field on_close function?
+---@field filetype string: The filetype to assign to the prompt buffer
 
 ---@class CodyPrompt
 ---@field open function(self): Open the window and bufnr, mutating self to store new win and bufnr
@@ -70,6 +67,8 @@ function CodyPrompt:show()
   self:open()
   vim.api.nvim_set_current_win(self.win)
   vim.api.nvim_buf_set_name(self.bufnr, string.format("Cody Prompt (%d)", self.bufnr))
+
+  vim.bo[self.bufnr].filetype = self.opts.filetype or "markdown.cody_prompt"
 end
 
 function CodyPrompt:delete()

--- a/lua/sg/config.lua
+++ b/lua/sg/config.lua
@@ -6,6 +6,10 @@
 --- <code=lua>
 ---   require("sg").setup { ... }
 --- </code>
+---
+--- Other configuration notes:
+--- - To configure options for the prompt, you can use `ftplugin/cody_prompt.lua`
+--- - To configure options for the history, you can use `ftplugin/cody_history.lua`
 ---@brief ]]
 
 ---@config { field_heading = "Configuration Options", space_prefix = 2 }


### PR DESCRIPTION
Users can configure prompt and history buffers with normal `ftplugin` methods