### PR TITLE
Make the chat history experience more consistent

### DIFF
--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -119,21 +119,18 @@ Default commands for interacting with Cody
 :CodyChat {module} ~
     State a new cody chat, with an optional {title}
 
-                                                                  *:CodyFloat*
-:CodyFloat {module} ~
-    State a new cody chat in a floating window
-
                                                                      *:CodyDo*
 :CodyDo {module} ~
     Instruct Cody to perform a task on selected text.
 
-                                                                 *:CodyToggle*
-:CodyToggle ~
-    Toggles the current Cody Chat window.
+                                                                   *:CodyTask*
+:CodyTask ~
+    Opens the last active CodyTask.
 
-                                                                *:CodyHistory*
-:CodyHistory ~
-    Select a previous chat from the current neovim session
+                                                               *:CodyTaskNext*
+:CodyTaskNext ~
+    Cycles to the next CodyTask. Navigates to the appropriate buffer location. 
+    Can also be triggered by pressing ']' while a task is open.
 
 
 

--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -137,10 +137,6 @@ Default commands for interacting with Cody
 
 
 
-M.tasks()                                                       *cody.tasks()*
-
-
-
 
 ================================================================================
 COMMANDS                                                         *cody.commands*

--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -123,12 +123,12 @@ Default commands for interacting with Cody
 :CodyToggle ~
     Toggles the current Cody Chat window.
 
-                                                                     *:CodyDo*
-:CodyDo {module} ~
+                                                                   *:CodyTask*
+:CodyTask {module} ~
     Instruct Cody to perform a task on selected text.
 
-                                                                   *:CodyTask*
-:CodyTask ~
+                                                               *:CodyTaskView*
+:CodyTaskView ~
     Opens the last active CodyTask.
 
                                                              *:CodyTaskAccept*

--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -127,6 +127,10 @@ Default commands for interacting with Cody
 :CodyTask {module} ~
     Instruct Cody to perform a task on selected text.
 
+                                                                     *:CodyDo*
+:CodyDo ~
+    @deprecated DEPRECATED. Use CodyTask.
+
                                                                *:CodyTaskView*
 :CodyTaskView ~
     Opens the last active CodyTask.

--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -119,6 +119,10 @@ Default commands for interacting with Cody
 :CodyChat {module} ~
     State a new cody chat, with an optional {title}
 
+                                                                 *:CodyToggle*
+:CodyToggle ~
+    Toggles the current Cody Chat window.
+
                                                                      *:CodyDo*
 :CodyDo {module} ~
     Instruct Cody to perform a task on selected text.
@@ -127,10 +131,20 @@ Default commands for interacting with Cody
 :CodyTask ~
     Opens the last active CodyTask.
 
+                                                             *:CodyTaskAccept*
+:CodyTaskAccept ~
+    Accepts the current CodyTask, removing it from the pending tasks list and
+    applying it to the selection the task was performed on. Can also be
+    triggered by pressing <CR> while a task is open.
+
+                                                               *:CodyTaskPrev*
+:CodyTaskPrev ~
+    Cycles to the previous CodyTask. Navigates to the appropriate buffer
+    location.
+
                                                                *:CodyTaskNext*
 :CodyTaskNext ~
-    Cycles to the next CodyTask. Navigates to the appropriate buffer location. 
-    Can also be triggered by pressing ']' while a task is open.
+    Cycles to the next CodyTask. Navigates to the appropriate buffer location.
 
 
 

--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -137,6 +137,10 @@ Default commands for interacting with Cody
 
 
 
+M.tasks()                                                       *cody.tasks()*
+
+
+
 
 ================================================================================
 COMMANDS                                                         *cody.commands*

--- a/lua/sg/cody/commands.lua
+++ b/lua/sg/cody/commands.lua
@@ -98,7 +98,7 @@ end
 commands.do_task = function(bufnr, start_line, end_line, message)
   local selection = vim.api.nvim_buf_get_lines(bufnr, start_line, end_line, false)
 
-  local formatted = require("sg.utils").format_code(bufnr, selection)
+  local formatted = util.format_code(bufnr, selection)
 
   local prompt = message
   prompt = prompt .. "\nReply only with code, nothing else\n"

--- a/lua/sg/cody/message.lua
+++ b/lua/sg/cody/message.lua
@@ -3,7 +3,6 @@ local Speaker = require "sg.cody.speaker"
 ---@class CodyMessage
 ---@field speaker CodySpeaker
 ---@field msg string[]
----@field ephemeral boolean
 ---@field hidden boolean
 ---@field contextFiles CodyContextFile[]?
 local Message = {}
@@ -13,7 +12,7 @@ Message.__index = Message
 ---@param speaker CodySpeaker
 ---@param msg string[]
 ---@param contextFiles CodyContextFile[]?
----@param opts { ephemeral?: boolean; hidden?: boolean }?
+---@param opts { hidden: boolean? }?
 ---@return CodyMessage
 function Message.init(speaker, msg, contextFiles, opts)
   opts = opts or {}
@@ -23,7 +22,6 @@ function Message.init(speaker, msg, contextFiles, opts)
     msg = msg,
     contextFiles = contextFiles,
     hidden = opts.hidden or false,
-    ephemeral = opts.ephemeral or false,
   }, Message)
 end
 

--- a/lua/sg/cody/message.lua
+++ b/lua/sg/cody/message.lua
@@ -35,7 +35,7 @@ function Message:render()
 
   if self.speaker == Speaker.cody then
     local out = {}
-    if #self.contextFiles > 0 then
+    if self.contextFiles and #self.contextFiles > 0 then
       table.insert(out, "{{{ " .. tostring(#self.contextFiles) .. " context files")
       for _, v in ipairs(self.contextFiles) do
         table.insert(out, "- " .. v.fileName)

--- a/lua/sg/cody/rpc.lua
+++ b/lua/sg/cody/rpc.lua
@@ -56,7 +56,7 @@ local track = function(msg)
   end
 end
 
----@type table<string, CodyChatCallback?>
+---@type table<string, CodyMessageHandler?>
 M.message_callbacks = {}
 
 ---@type {["chat/updateMessageInProgress"]: fun(noti: CodyChatUpdateMessageInProgressNoti?)}
@@ -241,7 +241,7 @@ end
 --- Sadly just puts whatever we get as the response into the currently
 --- open window... I will fix this later (needs protocol changes)
 ---@param message string
----@param callback CodyChatCallback
+---@param callback CodyMessageHandler
 ---@return table | nil
 ---@return table | nil
 M.execute.chat_question = function(message, callback)
@@ -255,7 +255,7 @@ end
 --- Execute a code question and get a streaming response
 --- Returns only code (hopefully)
 ---@param message string
----@param callback CodyChatCallback
+---@param callback CodyMessageHandler
 ---@return table | nil
 ---@return table | nil
 M.execute.code_question = function(message, callback)

--- a/lua/sg/cody/state.lua
+++ b/lua/sg/cody/state.lua
@@ -37,7 +37,7 @@ function State.last()
   return last_state
 end
 
---- Add a new message
+--- Add a new message and return its id
 ---@param message CodyMessage
 ---@return number
 function State:append(message)
@@ -47,8 +47,7 @@ function State:append(message)
   return #self.messages
 end
 
---- Update the last message
---- TODO: Should add a filter or some way to track the message down
+--- Replace the message with the provided id with the new message
 ---@param id number
 ---@param message CodyMessage
 function State:update_message(id, message)

--- a/lua/sg/cody/state.lua
+++ b/lua/sg/cody/state.lua
@@ -113,11 +113,13 @@ function State:render(bufnr, win, s, e)
     end
   end
 
-  local first_line = rendered_lines[1]
-  if first_line:sub(1, 3) == "```" then
-    local lang = first_line:sub(4)
-    vim.bo[bufnr].filetype = lang
-    rendered_lines = { unpack(rendered_lines, 2, #rendered_lines - 1) }
+  if #rendered_lines > 0 then
+    local first_line = rendered_lines[1]
+    if first_line:sub(1, 3) == "```" then
+      local lang = first_line:sub(4)
+      vim.bo[bufnr].filetype = lang
+      rendered_lines = { unpack(rendered_lines, 2, #rendered_lines - 1) }
+    end
   end
 
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, rendered_lines)

--- a/lua/sg/cody/state.lua
+++ b/lua/sg/cody/state.lua
@@ -97,9 +97,13 @@ function State:render(bufnr, win, render_opts)
   -- TODO: It should be possible to not wipe away the whole buffer, but I think it's fine for now.
   --       (main reason I mention is cause maybe extmarks would be more effective at maintaing messages)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
+  local messages = self.messages
+  if render_opts then
+    messages = { unpack(messages, render_opts.start, render_opts.finish) }
+  end
 
   local rendered_lines = {}
-  for _, message in ipairs { unpack(self.messages, render_opts.start, render_opts.finish) } do
+  for _, message in ipairs(messages) do
     if #rendered_lines > 0 then
       table.insert(rendered_lines, "")
     end

--- a/lua/sg/cody/state.lua
+++ b/lua/sg/cody/state.lua
@@ -113,6 +113,13 @@ function State:render(bufnr, win, s, e)
     end
   end
 
+  local first_line = rendered_lines[1]
+  if first_line:sub(1, 3) == "```" then
+    local lang = first_line:sub(4)
+    vim.bo[bufnr].filetype = lang
+    rendered_lines = { unpack(rendered_lines, 2, #rendered_lines - 1) }
+  end
+
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, rendered_lines)
 
   local linecount = vim.api.nvim_buf_line_count(bufnr)

--- a/lua/sg/cody/state.lua
+++ b/lua/sg/cody/state.lua
@@ -63,27 +63,26 @@ end
 --- Get a new completion, based on the state
 ---@param bufnr number
 ---@param win number
----@param callback CodyChatCallback
+---@param callback CodyChatCallbackHandler
 ---@param opts CompleteOpts?
+---@return number: message ID where completion will happen
 function State:complete(bufnr, win, callback, opts)
   set_last_state(self)
 
-  local snippet = ""
-  for _, message in ipairs(self.messages) do
-    if message.speaker == Speaker.user then
-      snippet = snippet .. table.concat(message.msg, "\n") .. "\n"
-    end
-  end
+  local snippet = table.concat(self.messages[#self.messages].msg, "\n") .. "\n"
 
   self:render(bufnr, win)
   vim.cmd [[mode]]
 
+  local id = self:append(Message.init(Speaker.cody, { "Loading ..." }, {}))
   -- Execute chat question. Will be completed async
   if opts and opts.code_only then
-    require("sg.cody.rpc").execute.code_question(snippet, callback)
+    require("sg.cody.rpc").execute.code_question(snippet, callback(id))
   else
-    require("sg.cody.rpc").execute.chat_question(snippet, callback)
+    require("sg.cody.rpc").execute.chat_question(snippet, callback(id))
   end
+
+  return id
 end
 
 --- Render the state to a buffer and window

--- a/lua/sg/cody/tasks.lua
+++ b/lua/sg/cody/tasks.lua
@@ -32,9 +32,6 @@ CodyTask.init = function(opts)
 
   local layout = CodyHover.init {
     bufnr = opts.bufnr,
-    history = {
-      filetype = vim.bo[opts.bufnr].filetype,
-    },
   }
   layout.state:append(Message.init(Speaker.user, vim.split(opts.task, "\n"), {}))
 
@@ -49,7 +46,7 @@ CodyTask.init = function(opts)
 
   layout:run(function()
     layout:show()
-    local id = layout:request_completion(true)
+    local id = layout:request_completion(true, vim.bo[opts.bufnr].filetype)
     task.message_id = id
     layout:show(id, id)
   end)

--- a/lua/sg/cody/tasks.lua
+++ b/lua/sg/cody/tasks.lua
@@ -82,7 +82,7 @@ function CodyTask:show()
     vim.cmd "CodyTaskNext"
   end)
   keymaps.map(self.layout.history.bufnr, "n", "[", "", function()
-    vim.cmd "CodyTaskPrevious"
+    vim.cmd "CodyTaskPrev"
   end)
 end
 

--- a/lua/sg/cody/tasks.lua
+++ b/lua/sg/cody/tasks.lua
@@ -71,7 +71,7 @@ function CodyTask:show()
   vim.api.nvim_set_current_buf(self.bufnr)
   local start_line = vim.api.nvim_buf_get_extmark_by_id(self.bufnr, self.marks_namespace, self.start_mark_id, {})[1]
   vim.api.nvim_win_set_cursor(0, { start_line, 0 })
-  self.layout:show(self.message_id, self.message_id)
+  self.layout:show { start = self.message_id, finish = self.message_id }
 
   -- TODO: We should expose these as lua functions and use them here.
   -- I don't like making the command strings the primary way of interacting

--- a/lua/sg/cody/tasks.lua
+++ b/lua/sg/cody/tasks.lua
@@ -46,9 +46,10 @@ CodyTask.init = function(opts)
 
   layout:run(function()
     layout:show()
+    layout:hide()
     local id = layout:request_completion(true, vim.bo[opts.bufnr].filetype)
     task.message_id = id
-    layout:show(id, id)
+    task:show()
   end)
 
   return task
@@ -74,6 +75,12 @@ function CodyTask:show()
 
   keymaps.map(self.layout.history.bufnr, "n", "<CR>", "", function()
     vim.cmd "CodyTaskAccept"
+  end)
+  keymaps.map(self.layout.history.bufnr, "n", "]", "", function()
+    vim.cmd "CodyTaskNext"
+  end)
+  keymaps.map(self.layout.history.bufnr, "n", "[", "", function()
+    vim.cmd "CodyTaskPrevious"
   end)
 end
 

--- a/lua/sg/cody/tasks.lua
+++ b/lua/sg/cody/tasks.lua
@@ -73,6 +73,8 @@ function CodyTask:show()
   vim.api.nvim_win_set_cursor(0, { start_line, 0 })
   self.layout:show(self.message_id, self.message_id)
 
+  -- TODO: We should expose these as lua functions and use them here.
+  -- I don't like making the command strings the primary way of interacting
   keymaps.map(self.layout.history.bufnr, "n", "<CR>", "", function()
     vim.cmd "CodyTaskAccept"
   end)

--- a/lua/sg/cody/tasks.lua
+++ b/lua/sg/cody/tasks.lua
@@ -37,21 +37,24 @@ CodyTask.init = function(opts)
     },
   }
   layout.state:append(Message.init(Speaker.user, vim.split(opts.task, "\n"), {}))
-  local id = layout.state:append(Message.init(Speaker.cody, { "Loading ..." }, {}))
-  layout:run(function()
-    layout:show(id, id)
-    layout:request_completion(true, id)
-  end)
 
-  return setmetatable({
+  local task = setmetatable({
     bufnr = opts.bufnr,
     marks_namespace = marks_namespace,
     start_mark_id = start_mark_id,
     end_mark_id = end_mark_id,
     task = opts.task,
     layout = layout,
-    message_id = id,
   }, CodyTask)
+
+  layout:run(function()
+    layout:show()
+    local id = layout:request_completion(true)
+    task.message_id = id
+    layout:show(id, id)
+  end)
+
+  return task
 end
 
 function CodyTask:apply()

--- a/lua/sg/components/cody_history.lua
+++ b/lua/sg/components/cody_history.lua
@@ -37,7 +37,7 @@ function CodyHistory:show()
   vim.api.nvim_buf_set_name(self.bufnr, string.format("Cody History (%d)", self.bufnr))
   vim.wo[self.win].foldmethod = "marker"
 
-  vim.bo[self.bufnr].filetype = self.opts.filetype or "markdown.cody_history"
+  vim.bo[self.bufnr].filetype = "markdown.cody_history"
 end
 
 function CodyHistory:delete()

--- a/lua/sg/components/cody_history.lua
+++ b/lua/sg/components/cody_history.lua
@@ -37,7 +37,7 @@ function CodyHistory:show()
   vim.api.nvim_buf_set_name(self.bufnr, string.format("Cody History (%d)", self.bufnr))
   vim.wo[self.win].foldmethod = "marker"
 
-  vim.bo[self.bufnr].filetype = "markdown.cody_history"
+  vim.bo[self.bufnr].filetype = self.opts.filetype or "markdown.cody_history"
 end
 
 function CodyHistory:delete()

--- a/lua/sg/components/layout/base.lua
+++ b/lua/sg/components/layout/base.lua
@@ -14,6 +14,10 @@ local State = require "sg.cody.state"
 ---@field prompt CodyPromptOpts?
 ---@field history CodyHistoryOpts
 
+---@class CodyLayoutRenderOpts
+---@field start number?
+---@field finish number?
+
 ---@class CodyBaseLayout
 ---@field opts CodyBaseLayoutOpts
 ---@field state CodyState
@@ -120,11 +124,10 @@ function Base:create()
   self.created = true
 end
 
---- Something
+--- Show the layout
 ---@param self CodyBaseLayout
----@param s number?
----@param e number?
-function Base:show(s, e)
+---@param render_opts CodyLayoutRenderOpts?
+function Base:show(render_opts)
   if not self.created then
     self:create()
   end
@@ -138,14 +141,14 @@ function Base:show(s, e)
   end
 
   self:set_keymaps()
-  self:render(s, e)
+  self:render(render_opts)
 end
 
----@param s number?
----@param e number?
-function Base:render(s, e)
+--- Render the layout with the current state
+---@param render_opts CodyLayoutRenderOpts?
+function Base:render(render_opts)
   if self.created then
-    self.state:render(self.history.bufnr, self.history.win, s, e)
+    self.state:render(self.history.bufnr, self.history.win, render_opts)
   end
 end
 

--- a/lua/sg/components/layout/base.lua
+++ b/lua/sg/components/layout/base.lua
@@ -29,7 +29,7 @@ Base.__index = Base
 function Base.init(opts)
   return setmetatable({
     opts = opts,
-    state = opts.state or State.init {
+    state = opts.state or State.last() or State.init {
       name = opts.name,
     },
   }, Base)
@@ -122,7 +122,9 @@ end
 
 --- Something
 ---@param self CodyBaseLayout
-function Base:show()
+---@param s number?
+---@param e number?
+function Base:show(s, e)
   if not self.created then
     self:create()
   end
@@ -136,12 +138,15 @@ function Base:show()
   end
 
   self:set_keymaps()
-  self:render()
+  self:render(s, e)
 end
 
-function Base:render()
+---comment
+---@param s number?
+---@param e number?
+function Base:render(s, e)
   if self.created then
-    self.state:render(self.history.bufnr, self.history.win)
+    self.state:render(self.history.bufnr, self.history.win, s, e)
   end
 end
 

--- a/lua/sg/components/layout/base.lua
+++ b/lua/sg/components/layout/base.lua
@@ -141,7 +141,6 @@ function Base:show(s, e)
   self:render(s, e)
 end
 
----comment
 ---@param s number?
 ---@param e number?
 function Base:render(s, e)

--- a/lua/sg/components/layout/float.lua
+++ b/lua/sg/components/layout/float.lua
@@ -130,14 +130,17 @@ function CodyFloat:set_keymaps()
   end)
 end
 
+---@return number
 function CodyFloat:request_completion()
   self:render()
   vim.api.nvim_buf_set_lines(self.prompt.bufnr, 0, -1, false, {})
 
+  local id = self.state:append(Message.init(Speaker.cody, { "Loading ..." }, {}))
   self.state:complete(self.history.bufnr, self.history.win, function(msg)
-    self.state:update_message(Message.init(Speaker.cody, vim.split(msg.text, "\n"), {}))
+    self.state:update_message(id, Message.init(Speaker.cody, vim.split(msg.text, "\n"), {}))
     self:render()
   end)
+  return id
 end
 
 return CodyFloat

--- a/lua/sg/components/layout/float.lua
+++ b/lua/sg/components/layout/float.lua
@@ -135,12 +135,12 @@ function CodyFloat:request_completion()
   self:render()
   vim.api.nvim_buf_set_lines(self.prompt.bufnr, 0, -1, false, {})
 
-  local id = self.state:append(Message.init(Speaker.cody, { "Loading ..." }, {}))
-  self.state:complete(self.history.bufnr, self.history.win, function(msg)
-    self.state:update_message(id, Message.init(Speaker.cody, vim.split(msg.text, "\n"), {}))
-    self:render()
+  return self.state:complete(self.history.bufnr, self.history.win, function(id)
+    return function(msg)
+      self.state:update_message(id, Message.init(Speaker.cody, vim.split(msg.text, "\n"), {}))
+      self:render()
+    end
   end)
-  return id
 end
 
 return CodyFloat

--- a/lua/sg/components/layout/float.lua
+++ b/lua/sg/components/layout/float.lua
@@ -136,6 +136,8 @@ function CodyFloat:request_completion()
   self:render()
   vim.api.nvim_buf_set_lines(self.prompt.bufnr, 0, -1, false, {})
 
+  -- TODO: I find this indirection really hard to track since we're generate a closure here.
+  -- I wonder if we can change this or just parameterize in a new way.
   return self.state:complete(self.history.bufnr, self.history.win, function(id)
     return function(msg)
       self.state:update_message(id, Message.init(Speaker.cody, vim.split(msg.text, "\n"), {}))

--- a/lua/sg/components/layout/float.lua
+++ b/lua/sg/components/layout/float.lua
@@ -130,6 +130,7 @@ function CodyFloat:set_keymaps()
   end)
 end
 
+--- Requests a completion and returns the message id where the completion will happen
 ---@return number
 function CodyFloat:request_completion()
   self:render()

--- a/lua/sg/components/layout/hover.lua
+++ b/lua/sg/components/layout/hover.lua
@@ -58,6 +58,8 @@ function CodyHover.init(opts)
   return setmetatable(object, CodyHover) --[[@as CodyLayoutHover]]
 end
 
+---@param s number?
+---@param e number?
 function CodyHover:show(s, e)
   self.super.show(self, s, e)
   vim.api.nvim_set_current_win(self.history.win)

--- a/lua/sg/components/layout/hover.lua
+++ b/lua/sg/components/layout/hover.lua
@@ -103,8 +103,9 @@ end
 
 ---Returns the id of the message where the completion will be.
 ---@param code_only boolean
+---@param filetype string
 ---@return number
-function CodyHover:request_completion(code_only)
+function CodyHover:request_completion(code_only, filetype)
   self:render()
 
   return self.state:complete(self.history.bufnr, self.history.win, function(id)
@@ -119,6 +120,11 @@ function CodyHover:request_completion(code_only)
           end
         end
         table.insert(render_lines, line)
+      end
+
+      if code_only then
+        render_lines = { "```" .. filetype, unpack(render_lines) }
+        table.insert(render_lines, "```")
       end
 
       self.state:update_message(id, Message.init(Speaker.cody, render_lines, {}))

--- a/lua/sg/components/layout/hover.lua
+++ b/lua/sg/components/layout/hover.lua
@@ -100,28 +100,29 @@ function CodyHover:set_keymaps()
 end
 
 ---Returns the id of the message where the completion will be.
----@param id number: message id where completion should be made
+---@param code_only boolean
 ---@return number
-function CodyHover:request_completion(code_only, id)
+function CodyHover:request_completion(code_only)
   self:render()
 
-  self.state:complete(self.history.bufnr, self.history.win, function(msg)
-    local lines = vim.split(msg.text, "\n")
-    local render_lines = {}
-    for _, line in ipairs(lines) do
-      if code_only then
-        if vim.trim(line) == "```" then
-          require("sg.cody.rpc").message_callbacks[msg.data.id] = nil
-          break
+  return self.state:complete(self.history.bufnr, self.history.win, function(id)
+    return function(msg)
+      local lines = vim.split(msg.text, "\n")
+      local render_lines = {}
+      for _, line in ipairs(lines) do
+        if code_only then
+          if vim.trim(line) == "```" then
+            require("sg.cody.rpc").message_callbacks[msg.data.id] = nil
+            break
+          end
         end
+        table.insert(render_lines, line)
       end
-      table.insert(render_lines, line)
-    end
 
-    self.state:update_message(id, Message.init(Speaker.cody, render_lines, {}))
-    self:render(id, id)
+      self.state:update_message(id, Message.init(Speaker.cody, render_lines, {}))
+      self:render(id, id)
+    end
   end, { code_only = code_only })
-  return id
 end
 
 return CodyHover

--- a/lua/sg/components/layout/hover.lua
+++ b/lua/sg/components/layout/hover.lua
@@ -58,10 +58,10 @@ function CodyHover.init(opts)
   return setmetatable(object, CodyHover) --[[@as CodyLayoutHover]]
 end
 
----@param s number?
----@param e number?
-function CodyHover:show(s, e)
-  self.super.show(self, s, e)
+--- Show current Hovered layout
+---@param render_opts CodyLayoutRenderOpts?
+function CodyHover:show(render_opts)
+  self.super.show(self, render_opts)
   vim.api.nvim_set_current_win(self.history.win)
 end
 
@@ -128,7 +128,7 @@ function CodyHover:request_completion(code_only, filetype)
       end
 
       self.state:update_message(id, Message.init(Speaker.cody, render_lines, {}))
-      self:render(id, id)
+      self:render { start = id, finish = id }
     end
   end, { code_only = code_only })
 end

--- a/lua/sg/components/layout/hover.lua
+++ b/lua/sg/components/layout/hover.lua
@@ -58,8 +58,8 @@ function CodyHover.init(opts)
   return setmetatable(object, CodyHover) --[[@as CodyLayoutHover]]
 end
 
-function CodyHover:show()
-  self.super.show(self)
+function CodyHover:show(s, e)
+  self.super.show(self, s, e)
   vim.api.nvim_set_current_win(self.history.win)
 end
 
@@ -99,7 +99,10 @@ function CodyHover:set_keymaps()
   end)
 end
 
-function CodyHover:request_completion(code_only)
+---Returns the id of the message where the completion will be.
+---@param id number: message id where completion should be made
+---@return number
+function CodyHover:request_completion(code_only, id)
   self:render()
 
   self.state:complete(self.history.bufnr, self.history.win, function(msg)
@@ -115,9 +118,10 @@ function CodyHover:request_completion(code_only)
       table.insert(render_lines, line)
     end
 
-    self.state:update_message(Message.init(Speaker.cody, render_lines, {}))
-    self:render()
+    self.state:update_message(id, Message.init(Speaker.cody, render_lines, {}))
+    self:render(id, id)
   end, { code_only = code_only })
+  return id
 end
 
 return CodyHover

--- a/lua/sg/components/layout/split.lua
+++ b/lua/sg/components/layout/split.lua
@@ -111,12 +111,12 @@ function CodySplit:request_completion()
   self:render()
   vim.api.nvim_buf_set_lines(self.prompt.bufnr, 0, -1, false, {})
 
-  local id = self.state:append(Message.init(Speaker.cody, { "Loading ..." }, {}))
-  self.state:complete(self.history.bufnr, self.history.win, function(msg)
-    self.state:update_message(id, Message.init(Speaker.cody, vim.split(msg.text, "\n"), msg.contextFiles))
-    self:render()
+  return self.state:complete(self.history.bufnr, self.history.win, function(id)
+    return function(msg)
+      self.state:update_message(id, Message.init(Speaker.cody, vim.split(msg.text, "\n"), msg.contextFiles))
+      self:render()
+    end
   end)
-  return id
 end
 
 return CodySplit

--- a/lua/sg/components/layout/split.lua
+++ b/lua/sg/components/layout/split.lua
@@ -105,14 +105,18 @@ function CodySplit:set_keymaps()
   end)
 end
 
+---Returns the id of the message where the completion will go
+---@return number
 function CodySplit:request_completion()
   self:render()
   vim.api.nvim_buf_set_lines(self.prompt.bufnr, 0, -1, false, {})
 
+  local id = self.state:append(Message.init(Speaker.cody, { "Loading ..." }, {}))
   self.state:complete(self.history.bufnr, self.history.win, function(msg)
-    self.state:update_message(Message.init(Speaker.cody, vim.split(msg.text, "\n"), msg.contextFiles))
+    self.state:update_message(id, Message.init(Speaker.cody, vim.split(msg.text, "\n"), msg.contextFiles))
     self:render()
   end)
+  return id
 end
 
 return CodySplit

--- a/lua/sg/document.lua
+++ b/lua/sg/document.lua
@@ -8,7 +8,7 @@ document.is_useful = function(bufnr)
   end
 
   local bo = vim.bo[bufnr]
-  if bo.buflisted == 0 then
+  if not bo.buflisted then
     return false
   end
 

--- a/lua/sg/extensions/cmp.lua
+++ b/lua/sg/extensions/cmp.lua
@@ -50,6 +50,7 @@ local cmp = require "cmp"
 local cmp_types = require "cmp.types.lsp"
 
 local commands = require "sg.cody.commands"
+local document = require "sg.document"
 
 local M = {}
 
@@ -75,6 +76,13 @@ end
 source.complete = function(self, params, callback)
   _ = self
   _ = params
+
+  -- Don't trigger completions on useless buffers.
+  -- This messes up the state of the agent.
+  local bufnr = vim.api.nvim_get_current_buf()
+  if not document.is_useful(bufnr) then
+    return
+  end
 
   commands.autocomplete(nil, function(data)
     local items = {}

--- a/lua/sg/types.lua
+++ b/lua/sg/types.lua
@@ -98,7 +98,9 @@ local M = {}
 ---@field text string?
 ---@field data any?
 
----@alias CodyChatCallback fun(msg: CodyChatMessage)
+---@alias CodyMessageHandler fun(msg: CodyChatMessage)
+
+---@alias CodyChatCallbackHandler fun(id: number): CodyMessageHandler
 
 ---@class CodyAutocompleteItem
 ---@field insertText string

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -59,7 +59,7 @@ vim.api.nvim_create_user_command("CodyTask", function(command)
   table.insert(M.tasks, task)
   M.active_task_index = #M.tasks
 end, { range = 2, nargs = 1 })
---
+
 ---@command :CodyDo [[
 ---@deprecated
 --- DEPRECATED. Use CodyTask.

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -59,6 +59,14 @@ vim.api.nvim_create_user_command("CodyTask", function(command)
   table.insert(M.tasks, task)
   M.active_task_index = #M.tasks
 end, { range = 2, nargs = 1 })
+--
+---@command :CodyDo [[
+---@deprecated
+--- DEPRECATED. Use CodyTask.
+---@command ]]
+vim.api.nvim_create_user_command("CodyDo", function(_)
+  error "CodyDo is deprecated. Use CodyTask instead."
+end, { range = 2, nargs = 1 })
 
 ---@command :CodyTaskView [[
 --- Opens the last active CodyTask.

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -43,14 +43,6 @@ vim.api.nvim_create_user_command("CodyChat", function(command)
   cody_commands.chat(name)
 end, { nargs = "*" })
 
----@command :CodyFloat {module} [[
---- State a new cody chat in a floating window
----@command ]]
-vim.api.nvim_create_user_command("CodyFloat", function(command)
-  local bufnr = vim.api.nvim_get_current_buf()
-  cody_commands.float(bufnr, command.line1 - 1, command.line2, command.args)
-end, { range = 2, nargs = 1 })
-
 ---@command :CodyDo {module} [[
 --- Instruct Cody to perform a task on selected text.
 ---@command ]]
@@ -61,7 +53,15 @@ vim.api.nvim_create_user_command("CodyDo", function(command)
   M.active_task_index = #M.tasks
 end, { range = 2, nargs = 1 })
 
+---@command :CodyTask [[
+--- Opens the last active CodyTask.
+---@command ]]
 vim.api.nvim_create_user_command("CodyTask", function()
+  if #M.tasks == 0 then
+    print "No pending tasks"
+    return
+  end
+
   if #M.tasks < M.active_task_index then
     M.active_task_index = #M.tasks
   end
@@ -71,6 +71,10 @@ vim.api.nvim_create_user_command("CodyTask", function()
   end
 end, {})
 
+---@command :CodyTaskNext [[
+--- Cycles to the next CodyTask. Navigates to the appropriate buffer location.
+--- Can also be triggered by pressing ']' while a task is open.
+---@command ]]
 vim.api.nvim_create_user_command("CodyTaskNext", function()
   if #M.tasks == 0 then
     print "No pending tasks"
@@ -87,6 +91,10 @@ vim.api.nvim_create_user_command("CodyTaskNext", function()
   M.tasks[M.active_task_index]:show()
 end, {})
 
+---@command :CodyTaskPrev [[
+--- Cycles to the previous CodyTask. Navigates to the appropriate buffer location.
+--- Can also be triggered by pressing '[' while a task is open.
+---@command ]]
 vim.api.nvim_create_user_command("CodyTaskPrevious", function()
   if #M.tasks == 0 then
     print "No pending tasks"
@@ -103,6 +111,11 @@ vim.api.nvim_create_user_command("CodyTaskPrevious", function()
   M.tasks[M.active_task_index]:show()
 end, {})
 
+---@command :CodyTaskAccept [[
+--- Accepts the current CodyTask, removing it from the pending tasks list and applying
+--- it to the selection the task was performed on.
+--- Can also be triggered by pressing <CR> while a task is open.
+---@command ]]
 vim.api.nvim_create_user_command("CodyTaskAccept", function()
   if #M.tasks == 0 then
     print "No pending tasks"
@@ -122,22 +135,5 @@ end, {})
 vim.api.nvim_create_user_command("CodyToggle", function(_)
   cody_commands.toggle()
 end, {})
-
----@command CodyHistory [[
---- Select a previous chat from the current neovim session
----@command ]]
-vim.api.nvim_create_user_command("CodyHistory", function()
-  cody_commands.history()
-end, {})
-
--- TODO: Decide if this makes sense to still be here after
--- using cody agent now.
-vim.api.nvim_create_user_command("CodyContext", function(command)
-  local bufnr = vim.api.nvim_get_current_buf()
-  local start_line = command.line1 - 1
-  local end_line = command.line2
-
-  cody_commands.add_context(bufnr, start_line, end_line)
-end, { range = 2 })
 
 return M

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -91,7 +91,7 @@ vim.api.nvim_create_user_command("CodyTaskNext", function()
   M.tasks[M.active_task_index]:show()
 end, {})
 
----@command :CodyTaskPrev [[
+---@command :CodyTaskPrevious [[
 --- Cycles to the previous CodyTask. Navigates to the appropriate buffer location.
 --- Can also be triggered by pressing '[' while a task is open.
 ---@command ]]

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -10,7 +10,6 @@ local cody_commands = require "sg.cody.commands"
 
 local M = {}
 
----@type CodyTask[]
 M.tasks = {}
 
 ---@command CodyAsk [[

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -43,6 +43,13 @@ vim.api.nvim_create_user_command("CodyChat", function(command)
   cody_commands.chat(name)
 end, { nargs = "*" })
 
+---@command :CodyToggle [[
+--- Toggles the current Cody Chat window.
+---@command ]]
+vim.api.nvim_create_user_command("CodyToggle", function(_)
+  cody_commands.toggle()
+end, {})
+
 ---@command :CodyDo {module} [[
 --- Instruct Cody to perform a task on selected text.
 ---@command ]]
@@ -71,46 +78,6 @@ vim.api.nvim_create_user_command("CodyTask", function()
   end
 end, {})
 
----@command :CodyTaskNext [[
---- Cycles to the next CodyTask. Navigates to the appropriate buffer location.
---- Can also be triggered by pressing ']' while a task is open.
----@command ]]
-vim.api.nvim_create_user_command("CodyTaskNext", function()
-  if #M.tasks == 0 then
-    print "No pending tasks"
-    return
-  end
-
-  if M.tasks[M.active_task_index] then
-    M.tasks[M.active_task_index].layout:hide()
-  end
-  M.active_task_index = M.active_task_index + 1
-  if M.active_task_index > #M.tasks then
-    M.active_task_index = 1
-  end
-  M.tasks[M.active_task_index]:show()
-end, {})
-
----@command :CodyTaskPrevious [[
---- Cycles to the previous CodyTask. Navigates to the appropriate buffer location.
---- Can also be triggered by pressing '[' while a task is open.
----@command ]]
-vim.api.nvim_create_user_command("CodyTaskPrevious", function()
-  if #M.tasks == 0 then
-    print "No pending tasks"
-    return
-  end
-
-  if M.tasks[M.active_task_index] then
-    M.tasks[M.active_task_index].layout:hide()
-  end
-  M.active_task_index = M.active_task_index - 1
-  if M.active_task_index < 1 then
-    M.active_task_index = #M.tasks
-  end
-  M.tasks[M.active_task_index]:show()
-end, {})
-
 ---@command :CodyTaskAccept [[
 --- Accepts the current CodyTask, removing it from the pending tasks list and applying
 --- it to the selection the task was performed on.
@@ -129,11 +96,42 @@ vim.api.nvim_create_user_command("CodyTaskAccept", function()
   end
 end, {})
 
----@command :CodyToggle [[
---- Toggles the current Cody Chat window.
+---@command :CodyTaskPrev [[
+--- Cycles to the previous CodyTask. Navigates to the appropriate buffer location.
 ---@command ]]
-vim.api.nvim_create_user_command("CodyToggle", function(_)
-  cody_commands.toggle()
+vim.api.nvim_create_user_command("CodyTaskPrev", function()
+  if #M.tasks == 0 then
+    print "No pending tasks"
+    return
+  end
+
+  if M.tasks[M.active_task_index] then
+    M.tasks[M.active_task_index].layout:hide()
+  end
+  M.active_task_index = M.active_task_index - 1
+  if M.active_task_index < 1 then
+    M.active_task_index = #M.tasks
+  end
+  M.tasks[M.active_task_index]:show()
+end, {})
+
+---@command :CodyTaskNext [[
+--- Cycles to the next CodyTask. Navigates to the appropriate buffer location.
+---@command ]]
+vim.api.nvim_create_user_command("CodyTaskNext", function()
+  if #M.tasks == 0 then
+    print "No pending tasks"
+    return
+  end
+
+  if M.tasks[M.active_task_index] then
+    M.tasks[M.active_task_index].layout:hide()
+  end
+  M.active_task_index = M.active_task_index + 1
+  if M.active_task_index > #M.tasks then
+    M.active_task_index = 1
+  end
+  M.tasks[M.active_task_index]:show()
 end, {})
 
 return M

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -10,6 +10,7 @@ local cody_commands = require "sg.cody.commands"
 
 local M = {}
 
+---@type CodyTask[]
 M.tasks = {}
 
 ---@command CodyAsk [[
@@ -83,6 +84,22 @@ vim.api.nvim_create_user_command("CodyTaskNext", function()
   M.active_task_index = M.active_task_index + 1
   if M.active_task_index > #M.tasks then
     M.active_task_index = 1
+  end
+  M.tasks[M.active_task_index]:show()
+end, {})
+
+vim.api.nvim_create_user_command("CodyTaskPrevious", function()
+  if #M.tasks == 0 then
+    print "No pending tasks"
+    return
+  end
+
+  if M.tasks[M.active_task_index] then
+    M.tasks[M.active_task_index].layout:hide()
+  end
+  M.active_task_index = M.active_task_index - 1
+  if M.active_task_index < 1 then
+    M.active_task_index = #M.tasks
   end
   M.tasks[M.active_task_index]:show()
 end, {})

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -50,20 +50,20 @@ vim.api.nvim_create_user_command("CodyToggle", function(_)
   cody_commands.toggle()
 end, {})
 
----@command :CodyDo {module} [[
+---@command :CodyTask {module} [[
 --- Instruct Cody to perform a task on selected text.
 ---@command ]]
-vim.api.nvim_create_user_command("CodyDo", function(command)
+vim.api.nvim_create_user_command("CodyTask", function(command)
   local bufnr = vim.api.nvim_get_current_buf()
   local task = cody_commands.do_task(bufnr, command.line1 - 1, command.line2, command.args)
   table.insert(M.tasks, task)
   M.active_task_index = #M.tasks
 end, { range = 2, nargs = 1 })
 
----@command :CodyTask [[
+---@command :CodyTaskView [[
 --- Opens the last active CodyTask.
 ---@command ]]
-vim.api.nvim_create_user_command("CodyTask", function()
+vim.api.nvim_create_user_command("CodyTaskView", function()
   if #M.tasks == 0 then
     print "No pending tasks"
     return

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -12,7 +12,7 @@ local M = {}
 
 M.tasks = {}
 
----@command CodyAsk [[
+---@command :CodyAsk [[
 --- Ask a question about the current selection.
 ---
 --- Use from visual mode to pass the current selection
@@ -129,7 +129,7 @@ vim.api.nvim_create_user_command("CodyTaskAccept", function()
   end
 end, {})
 
----@command CodyToggle [[
+---@command :CodyToggle [[
 --- Toggles the current Cody Chat window.
 ---@command ]]
 vim.api.nvim_create_user_command("CodyToggle", function(_)


### PR DESCRIPTION
Closes #97 

This PR irons out some core experiences when it comes to interacting with Cody, especially regarding the chat history.

1. Fix a bug where all the user chat messages are concatenated together and sent to Cody
  - Agent already keeps track of chat history, and doing this lead to some weird context behaviours
2. Remove the ability to create a new chat history
  - Having separate chat histories need to be supported by Agent first, otherwise we're going to have some _very_ weird leaky behaviour
3. Add <kbd>[</kbd> and <kbd>]</kbd> as keys to cycle through cody tasks
4. CodyTasks now form part of the chat history. This is how it is stored in Agent> I think it's better to make this visible than have weird context leaks.