### PR TITLE
doc: fix duplicate tag 'cody.commands'

### DIFF
--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -139,7 +139,7 @@ Default commands for interacting with Cody
 
 
 ================================================================================
-COMMANDS                                                         *cody.commands*
+COMMANDS                                                         *cody.lua-commands*
 
 commands.ask({bufnr}, {start_line}, {end_line}, {message}) *sg.cody.commands.ask()*
     Ask Cody about the selected code


### PR DESCRIPTION
There is a duplicate tag in the documentation: `cody.commands`.
One if for the `:CodyXxx` commands, and the other one if for the lua api for `commands.foo`.
I propose to rename the latter to `cody.lua-commands`.

If you have a better idea for the name, please do not hesitate to change.