### PR TITLE
Make CodyAsk work properly without a range

### DIFF
--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -156,7 +156,15 @@ Default commands for interacting with Cody
 ================================================================================
 LUA-COMMANDS                                                 *cody.lua-commands*
 
-commands.ask({bufnr}, {start_line}, {end_line}, {message}) *sg.cody.commands.ask()*
+commands.ask({message})                               *sg.cody.commands.ask()*
+    Ask Cody a question, without any selection
+
+
+    Parameters: ~
+        {message} (string)
+
+
+commands.ask_range({bufnr}, {start_line}, {end_line}, {message}) *sg.cody.commands.ask_range()*
     Ask Cody about the selected code
 
 

--- a/lua/sg/cody/commands.lua
+++ b/lua/sg/cody/commands.lua
@@ -19,12 +19,21 @@ local protocol = require "sg.cody.protocol"
 
 local commands = {}
 
+--- Ask Cody a question, without any selection
+---@param message string
+commands.ask = function(message)
+  local layout = CodySplit.init {}
+
+  local contents = vim.tbl_flatten(message)
+  layout:request_user_message(contents)
+end
+
 --- Ask Cody about the selected code
 ---@param bufnr number
 ---@param start_line number
 ---@param end_line number
 ---@param message string
-commands.ask = function(bufnr, start_line, end_line, message)
+commands.ask_range = function(bufnr, start_line, end_line, message)
   local selection = vim.api.nvim_buf_get_lines(bufnr, start_line, end_line, false)
   local layout = CodySplit.init {}
 

--- a/plugin/cody.lua
+++ b/plugin/cody.lua
@@ -18,8 +18,12 @@ M.tasks = {}
 --- Use from visual mode to pass the current selection
 ---@command ]]
 vim.api.nvim_create_user_command("CodyAsk", function(command)
-  local bufnr = vim.api.nvim_get_current_buf()
-  cody_commands.ask(bufnr, command.line1 - 1, command.line2, command.args)
+  if command.range == 0 then
+    cody_commands.ask(command.args)
+  else
+    local bufnr = vim.api.nvim_get_current_buf()
+    cody_commands.ask_range(bufnr, command.line1 - 1, command.line2, command.args)
+  end
 end, { range = 2, nargs = 1 })
 
 -- TODO: This isn't ready yet, but we should explore how to expose this


### PR DESCRIPTION
Previously `:CodyAsk` without a range would produce an empty context with nothing between three backticks.

This fixes that by calling different commands depending on whether there's a range or not.