### PR TITLE
fix: add name to lsp.start_client opts

### DIFF
--- a/lua/sg/lsp/init.lua
+++ b/lua/sg/lsp/init.lua
@@ -45,6 +45,7 @@ M.get_client_id = function()
   end
 
   M._client = vim.lsp.start_client {
+    name = "sourcegraph",
     cmd = { cmd },
     cmd_env = {
       SRC_ENDPOINT = auth.endpoint,


### PR DESCRIPTION
Just makes `sg.nvim` look nicer in `:LspInfo` :)