### PR TITLE
fix: handling the timeout case in checkhealth

### DIFF
--- a/lua/sg/health.lua
+++ b/lua/sg/health.lua
@@ -82,9 +82,13 @@ local report_env = function()
     return err or info
   end)
 
+  if err == nil and info == nil then
+    err = "Timed out waiting for response"
+  end
+
   if err then
     vim.health.error("  Sourcegraph Connection info failed: " .. vim.inspect(err))
-    ok = false
+    return false
   else
     vim.health.ok("  Sourcegraph Connection info: " .. vim.inspect(info))
   end


### PR DESCRIPTION
Hi,

For some reason, I had a timeout in the checkhealth.
The reason of the timeout is still mysterious to me, but anyway, it caused an exception because the checks continues and try to use the result of the timedout query.
Also, the timeout wasn't detected as an error so I added a corresponding check.