### PR TITLE
nix: add OPENSSL_NO_VENDOR env to cargo build process

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,8 @@
       }: let
         inherit (config.nci) outputs;
         withOpenSSL = {
+          # Needed to get openssl-sys to use pkgconfig.
+          env.OPENSSL_NO_VENDOR = "1";
           mkDerivation = {
             nativeBuildInputs = with pkgs; [pkg-config];
             buildInputs = with pkgs; [openssl] ++ lib.optionals pkgs.stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,13 @@
           };
           mkDerivation = {
             nativeBuildInputs = with pkgs; [pkg-config];
-            buildInputs = with pkgs; [openssl] ++ lib.optionals pkgs.stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];
+            buildInputs = with pkgs; [openssl] ++ lib.optionals pkgs.stdenv.isDarwin [
+              darwin.apple_sdk.frameworks.Security
+              darwin.apple_sdk.frameworks.SystemConfiguration
+            ];
+            prePatch = ''
+              rm .cargo/config.toml
+            '';
           };
         };
       in {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,9 @@
         inherit (config.nci) outputs;
         withOpenSSL = {
           # Needed to get openssl-sys to use pkgconfig.
-          env.OPENSSL_NO_VENDOR = "1";
+          env = lib.optionalAttrs pkgs.stdenv.isLinux {
+            OPENSSL_NO_VENDOR = true;
+          };
           mkDerivation = {
             nativeBuildInputs = with pkgs; [pkg-config];
             buildInputs = with pkgs; [openssl] ++ lib.optionals pkgs.stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];


### PR DESCRIPTION
after recent changes nix build started failing, this fixes the issue