### PR TITLE
fix: allow specifying search query in `:SourcegraphSearch` args

### DIFF
--- a/plugin/sg.lua
+++ b/plugin/sg.lua
@@ -196,4 +196,5 @@ vim.api.nvim_create_user_command("SourcegraphSearch", function(args)
   require("sg.extensions.telescope").fuzzy_search_results { input = input }
 end, {
   desc = "Run a search on your connected Sourcegraph instance",
+  nargs = '*',
 })

--- a/plugin/sg.lua
+++ b/plugin/sg.lua
@@ -196,5 +196,5 @@ vim.api.nvim_create_user_command("SourcegraphSearch", function(args)
   require("sg.extensions.telescope").fuzzy_search_results { input = input }
 end, {
   desc = "Run a search on your connected Sourcegraph instance",
-  nargs = '*',
+  nargs = "*",
 })


### PR DESCRIPTION
By default, `nargs` is set to `0` thus not allowing to specify search query through arguments.