### PR TITLE
Fix: node version parsing on Windows

### DIFF
--- a/lua/sg/utils.lua
+++ b/lua/sg/utils.lua
@@ -90,6 +90,10 @@ utils.valid_node_executable = function(executable)
   end
 
   local output = vim.fn.systemlist(executable .. " --version") or {}
+  -- systemlist() leaves CR behind on Windows, fixing inconsistency
+  for i = #output, 1, -1 do
+    output[i] = output[i]:gsub("\r$", "")
+  end
   return utils._validate_node_output(output)
 end
 


### PR DESCRIPTION
`vim.fn.systemlist()` emits carriage return along with node version string on Windows.
This breaks version parsing when the strict flag is on.
Cleaned up CRs to provide consistent output.

Fixes: #166 