### PR TITLE
fix: prevent typewriter for answers we already saw

### DIFF
--- a/lua/sg/cody/state.lua
+++ b/lua/sg/cody/state.lua
@@ -160,6 +160,11 @@ function State:render(bufnr, win)
     message_state.typewriter:render(bufnr, win, message_state.mark, { interval = interval })
 
     rendered = rendered + 1
+
+    -- /!\ TODO investigate, this is crude fix. 
+    -- Basically, the messages the user type are marked as completed, but the answers from Cody
+    -- are never marked as such even after being displayed. Forcing it to true fixes it.
+    message.completed = true
   end
 
   for _, message_state in ipairs(self.messages) do


### PR DESCRIPTION
It you CodyToggle three times (on, off and on again), prompts sent by the user are not rendered as typewrited, but the answers from Cody will be, making the UI very annoying to deal with.

This is a crude fix I did in between things during my evening, should be an okay bandage until we see if there's a better place to do this.

Basically, if a message has been rendered, it assumes it's been completed. So first time will have the effect, but not afterward.

Before: 

https://github.com/sourcegraph/sg.nvim/assets/10151/39f7d21e-2260-4a61-9656-a92928ae0914




After: 

It's instant for old interactions, as expected. Typewriter effect is still there for new answers.