### PR TITLE
Pin third-party GH actions

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -18,7 +18,7 @@ jobs:
     name: nix-build (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v22
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # SECURITY: pin third-party action hashes
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - run: nix build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # SECURITY: pin third-party action hashes
       - name: Install cargo-dist
         run: ${{ matrix.install_dist }}
       - name: Add aarch64 target
@@ -259,7 +259,7 @@ jobs:
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
       - name: Create Github Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # SECURITY: pin third-party action hashes
         with:
           tag: ${{ needs.plan.outputs.tag }}
           name: ${{ fromJson(needs.host.outputs.val).announcement_title }}


### PR DESCRIPTION
As recommended by GitHub this PR adds pinning of third-party GitHub actions. We've briefly reviewed the contents of the action for any potential issues. See https://github.com/sourcegraph/security-issues/issues/377 for more information.

The SHA hash for the Nix action is for `v26` which addresses [a vulnerability](https://github.com/cachix/install-nix-action/releases/tag/v26).