### PR TITLE
fix: accept_tos

### DIFF
--- a/lua/sg/config.lua
+++ b/lua/sg/config.lua
@@ -29,6 +29,7 @@
 ---@type sg.config
 local config = {
   enable_cody = true,
+  accept_tos = false,
   download_binaries = true,
   node_executable = "node",
   skip_node_check = false,


### PR DESCRIPTION
The ```if config[key] ~= nil then``` check in sg/init.lua prevents it from being set