### PR TITLE
Fix GitHub/GitLab brand capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Requires:
 - nvim 0.9 or nvim nightly
 - Node.js >= 18.17.0 (LTS) at runtime for [`cody-agent.js`](https://github.com/sourcegraph/cody)
 
-(By default, sg.nvim downloads released binaries from Github. If you prefer to build the plugin yourself, you'll need `cargo` to build)
+(By default, sg.nvim downloads released binaries from GitHub. If you prefer to build the plugin yourself, you'll need `cargo` to build)
 
 - Currently uses plenary.nvim and telescope.nvim for some features.
   - If you would like to use something else for search functionality, please make an issue and I can look into adding support.

--- a/doc/sg.txt
+++ b/doc/sg.txt
@@ -24,7 +24,7 @@ M.setup({opts})                                                    *M.setup()*
 
 
     Parameters: ~
-        {opts} (sg.config)
+        {opts} (sg)  .config
 
 
 
@@ -136,21 +136,13 @@ Default commands for interacting with Cody
 :CodyAsk ~
     Ask a question about the current selection.
 
-    Use from visual mode to pass the current selection
-
                                                                 *:CodyExplain*
 :CodyExplain ~
     Ask a question about the current selection.
 
-    Use from visual mode to pass the current selection
-
                                                                 *:CodyChat{!}*
 :CodyChat{!} {title} ~
     State a new cody chat, with an optional {title}
-
-    If {!} is passed, will reset the chat and start a new chat conversation.
-
-    For more configuation options, see: `:help sg.cody.commands.chat`
 
                                                                  *:CodyToggle*
 :CodyToggle ~
@@ -164,8 +156,6 @@ Default commands for interacting with Cody
 :CodyRestart ~
     Restarts Cody and Sourcegraph, clearing all state.
 
-    Useful if you've re-authenticated or are testing your config
-
 
 
 M.setup({config})                                               *cody.setup()*
@@ -173,7 +163,7 @@ M.setup({config})                                               *cody.setup()*
 
 
     Parameters: ~
-        {config} (sg.config)
+        {config} (sg)  .config
 
 
 
@@ -189,7 +179,7 @@ commands.ask_range({bufnr}, {start_row}, {end_row}, {message}, {opts}) *sg.cody.
         {start_row} (number)
         {end_row}   (number)
         {message}   (string)
-        {opts}      (cody.ChatOpts)
+        {opts}      (cody)    .ChatOpts
 
 
 commands.autocomplete({request}, {callback}) *sg.cody.commands.autocomplete()*
@@ -197,7 +187,7 @@ commands.autocomplete({request}, {callback}) *sg.cody.commands.autocomplete()*
 
 
     Parameters: ~
-        {request}  ({ filename: string, row: number, col: number }?)
+        {request}  ({ filename: string, row: number, col: number })      ?
         {callback} (function(err: table, data: CodyAutocompleteResult))
 
 
@@ -234,7 +224,7 @@ commands.chat({new}, {opts})                         *sg.cody.commands.chat()*
 
     Parameters: ~
         {new}  (boolean)
-        {opts} (cody.ChatOpts)
+        {opts} (cody)     .ChatOpts
 
 
 commands.toggle()                                  *sg.cody.commands.toggle()*
@@ -290,14 +280,7 @@ Default commands for interacting with Sourcegraph
 
                                                            *:SourcegraphLogin*
 :SourcegraphLogin ~
-    Get prompted for endpoint and access_token if you don't want to set them
-    via environment variables.
-
-    For enterprise instances, the only currently supported method is
-    environment variables.
-
-    If you want to force a particular endpoint + access token combination to be
-    saved, use :SourcegraphLogin! and then follow the prompts.
+    Get prompted for endpoint and access_token if you don't
 
                                                            *:SourcegraphClear*
 :SourcegraphClear ~
@@ -311,13 +294,11 @@ Default commands for interacting with Sourcegraph
                                                 *:SourcegraphDownloadBinaries*
 :SourcegraphDownloadBinaries ~
     (Re-)Download the sourcegraph binaries. This should happen during
-    installation but you can force redownloading the binaries this way to
-    ensure that sg.nvim is properly installed.
+    installation
 
                                                             *:SourcegraphLink*
 :SourcegraphLink ~
-    Get a sourcegraph link to the current repo + file + line. Automatically
-    adds it to your '+' register
+    Get a sourcegraph link to the current repo + file + line.
 
                                                           *:SourcegraphSearch*
 :SourcegraphSearch ~


### PR DESCRIPTION
This change ensures consistent capitalization of the GitHub and GitLab brand names in Markdown documentation.

[_Created by Sourcegraph batch change `sqs/capitalize-brands-correctly`._](https://sourcegraph.sourcegraph.com/users/sqs/batch-changes/capitalize-brands-correctly)