### PR TITLE
Update ubuntu in Github Actions to latest LTS (24.04)

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             rev: nightly/nvim-linux64.tar.gz
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             rev: v0.9.5/nvim-linux64.tar.gz
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             rev: v0.10.0/nvim-linux64.tar.gz
           - os: macos-latest
             rev: nightly/nvim-macos-x86_64.tar.gz


### PR DESCRIPTION
Test Plan: CI

[_Created by Sourcegraph batch change `keegan/update-old-ubuntu-on-github-actions`._](https://sourcegraph.sourcegraph.com/users/keegan/batch-changes/update-old-ubuntu-on-github-actions)